### PR TITLE
Fix broken link for 'Installing Devbox'

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ git clone --recurse-submodules git@github.com:sidpalas/devops-directive-github-a
 ```
 
 2. **Install DevBox** – DevBox bootstraps all required CLI tools (Go, Node.js, Python, `act`, `task`, `npc`, `civo`, `gh`, `jq`, `yq`, `kubectl`, `kluctl`, ...).  
-   Follow the official installation guide: <https://www.jetify.com/docs/devbox/installing_devbox/>
+   Follow the official installation guide: <https://www.jetify.com/docs/devbox/installing-devbox/index#>
    
    After installing devbox, run `devbox shell` to start a shell session with these tools installed/configured.
 


### PR DESCRIPTION
Under install `Install Devbox` in main README when navigating to https://www.jetify.com/docs/devbox/installing_devbox a 404 error is shown and this PR updates the link.