### PR TITLE
Update .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -12,4 +12,4 @@
 	url = https://github.com/sidpalas/shell-container-action.git
 [submodule "capstone"]
 	path = capstone
-	url = git@github.com:sidpalas/capstone.git
+	url = https://github.com/sidpalas/capstone.git


### PR DESCRIPTION
The capstone git submodule URL was configured to use SSH (git@github.com:...). This causes clones/CI to fail in environments that don’t have SSH keys configured or GitHub’s SSH host key trusted (e.g., Host key verification failed / permission issues). Switching the submodule URL to HTTPS makes submodule initialization work out-of-the-box with standard GitHub authentication and avoids SSH host-key setup requirements.