### PR TITLE
fix: env variable passed to the python container action

### DIFF
--- a/06-authoring-actions/container-actions/python-container-action/action.yaml
+++ b/06-authoring-actions/container-actions/python-container-action/action.yaml
@@ -14,10 +14,5 @@ runs:
   image: Dockerfile
   # Option B – use a pre-built image to avoid rebuilds:
   # image: docker://ghcr.io/your-org/hello-python-action:v1
-
-  # Passing the input as an environmental variable
-  env:
-    INPUT_WHO_TO_GREET: ${{ inputs.who-to-greet }}
-  # Passing the value in the args list
-  # args:
-  #   - ${{ inputs.who-to-greet }}
+  args:
+    - ${{ inputs.who-to-greet }}

--- a/06-authoring-actions/container-actions/python-container-action/action.yaml
+++ b/06-authoring-actions/container-actions/python-container-action/action.yaml
@@ -14,5 +14,10 @@ runs:
   image: Dockerfile
   # Option B – use a pre-built image to avoid rebuilds:
   # image: docker://ghcr.io/your-org/hello-python-action:v1
-  args:
-    - ${{ inputs.who-to-greet }}
+
+  # Passing the input as an environmental variable
+  env:
+    INPUT_WHO_TO_GREET: ${{ inputs.who-to-greet }}
+  # Passing the value in the args list
+  # args:
+  #   - ${{ inputs.who-to-greet }}

--- a/06-authoring-actions/container-actions/python-container-action/entrypoint.py
+++ b/06-authoring-actions/container-actions/python-container-action/entrypoint.py
@@ -2,11 +2,11 @@
 import os, datetime as dt
 
 
-# Read the input from the passed environmental variable
-name = os.getenv("INPUT_WHO_TO_GREET", "World")
+# GitHub injects INPUT_WHO-TO-GREET based on the input name (only spaces get replaced with underscores, not hyphens)
+name = os.getenv("INPUT_WHO-TO-GREET", "World")
 
 # Alternatively, you could read it from the args list using its position
-# (you would need to import sys package above, and uncomment the args in action.yaml)
+# (you would need to import sys package above)
 # name = sys.argv[1] if len(sys.argv) > 1 else "World"
 
 greeting = f"Hello, {name}! Time is {dt.datetime.now(dt.timezone.utc):%H:%M:%S} UTC."

--- a/06-authoring-actions/container-actions/python-container-action/entrypoint.py
+++ b/06-authoring-actions/container-actions/python-container-action/entrypoint.py
@@ -2,11 +2,11 @@
 import os, datetime as dt
 
 
-# GitHub injects INPUT_WHO_TO_GREET based on the input name
+# Read the input from the passed environmental variable
 name = os.getenv("INPUT_WHO_TO_GREET", "World")
 
 # Alternatively, you could read it from the args list using its position
-# (you would need to import sys package above)
+# (you would need to import sys package above, and uncomment the args in action.yaml)
 # name = sys.argv[1] if len(sys.argv) > 1 else "World"
 
 greeting = f"Hello, {name}! Time is {dt.datetime.now(dt.timezone.utc):%H:%M:%S} UTC."


### PR DESCRIPTION
This is a fix for the issue I created https://github.com/sidpalas/devops-directive-github-actions-course/issues/134

I added `INPUT_WHO_TO_GREET` to the [06-authoring-actions/container-actions/python-container-action/action.yaml](https://github.com/sidpalas/devops-directive-github-actions-course/blob/main/06-authoring-actions/container-actions/python-container-action/action.yaml), to be properly passed to the Python container as an environmental variable. 

I also commented out the `args` and added comments explaining the usage of environmental variables and argument list in both [action.yaml](https://github.com/sidpalas/devops-directive-github-actions-course/blob/main/06-authoring-actions/container-actions/python-container-action/action.yaml) and [entrypoint.py](https://github.com/sidpalas/devops-directive-github-actions-course/blob/main/06-authoring-actions/container-actions/python-container-action/entrypoint.py)